### PR TITLE
Fix `setState` callback

### DIFF
--- a/08.render-callback.jsx
+++ b/08.render-callback.jsx
@@ -40,10 +40,12 @@ class WindowWidth extends React.Component {
   componentDidMount() {
     this.setState(
       {width: window.innerWidth},
-      window.addEventListener(
-        "resize",
-        ({target}) => this.setState({width: target.innerWidth})
-      )
+      () => {
+        window.addEventListener(
+          "resize",
+          ({target}) => this.setState({width: target.innerWidth})
+        )
+      }
     )
   }
 


### PR DESCRIPTION
Second argument of `setState` should be wrapped with a function, otherwise `addEventListener` will execute before `setState`.