### PR TITLE
Add a word of caution about spread operator use

### DIFF
--- a/patterns/02.jsx-spread-attributes.md
+++ b/patterns/02.jsx-spread-attributes.md
@@ -53,6 +53,10 @@ const FancyDiv = ({ className, ...props }) => (
 );
 ```
 
+### A word of caution
+
+Although convenient, spread operators do increase the connascence (complexity or type of coupling) and may make debugging occur at run-time instead of before for the developer and any future maintainers. Also, it is better to use spread operators on props into components and then decontruct the object instead of blindly passing `props` onto React DOM Elements. Passing objects with undetermined contents onto React DOM Elements may increase the likelihood of invalid HTML attributes.
+
 ### References:
 
 [JSX Spread Attributes](https://gist.github.com/sebmarkbage/07bbe37bc42b6d4aef81)

--- a/patterns/02.jsx-spread-attributes.md
+++ b/patterns/02.jsx-spread-attributes.md
@@ -55,7 +55,7 @@ const FancyDiv = ({ className, ...props }) => (
 
 ### A word of caution
 
-Although convenient, spread operators do increase the connascence (complexity or type of coupling) and may make debugging occur at run-time instead of before for the developer and any future maintainers. Also, it is better to use spread operators on props into components and then decontruct the object instead of blindly passing `props` onto React DOM Elements. Passing objects with undetermined contents onto React DOM Elements may increase the likelihood of invalid HTML attributes.
+Although convenient, spread operators do increase the connascence (complexity or type of coupling) and may make debugging occur at run-time instead of before for the developer and any future maintainers. Also, it is better to use spread operators on props into components and then decontruct the object instead of blindly passing `props` onto React DOM Elements. This is an [anti-pattern](../anti-patterns/07.spreading-props-dom.md). Passing objects with undetermined contents onto React DOM Elements will increase the likelihood of invalid HTML attributes.
 
 ### References:
 


### PR DESCRIPTION
We thought the spread operator was very nifty and cool in our UI library until we discovered we had invalid HTML attributes all over the place. Now it's pretty much ban from the library, except for instances where the props are exactly the same (such as `Icon` props get passed into an `IconButton` which is an icon with an `onClick` callback).