### PR TITLE
Migrate from React.PropTypes

### DIFF
--- a/patterns/01.stateless-functions.md
+++ b/patterns/01.stateless-functions.md
@@ -10,7 +10,7 @@ Stateless functional components will soon offer improved performance as well.<br
 Since there’s no state or lifecycle methods to worry about, the React team plans to avoid unnecessary checks and memory allocations in future releases.
 
 ```javascript
-import { PropTypes } from "react";
+import PropTypes from 'prop-types';
 
 const Greeting = () => <div>Hi there!</div>;
 
@@ -55,4 +55,3 @@ Greeting.contextTypes = {
 - [Container Components and Stateless Functional Components in React](http://www.zsoltnagy.eu/container-components-and-stateless-functional-components-in-react/)
 - [Pros and Cons](http://stackoverflow.com/questions/40703675/react-functional-stateless-component-purecomponent-component-what-are-the-dif)
 - [Minor Optimization](http://cooperm.com/2016/10/19/clean-up-stateless-react-components-with-inline-render-functions/)
-

--- a/patterns/20.dependency-injection.md
+++ b/patterns/20.dependency-injection.md
@@ -105,7 +105,7 @@ class App extends React.Component {
 }
 
 App.childContextTypes = {
-  title: React.PropTypes.string
+  title: PropTypes.string
 };
 
 // a place where we need data
@@ -116,6 +116,6 @@ class Inject extends React.Component {
   }
 }
 Inject.contextTypes = {
-  title: React.PropTypes.string
+  title: PropTypes.string
 };
 ```

--- a/patterns/21.context-wrapper.md
+++ b/patterns/21.context-wrapper.md
@@ -28,9 +28,9 @@ class App extends React.Component {
 }
 
 App.childContextTypes = {
-  data: React.PropTypes.object,
-  get: React.PropTypes.func,
-  register: React.PropTypes.func
+  data: PropTypes.object,
+  get: PropTypes.func,
+  register: PropTypes.func
 };
 ```
 And our Title component gets it's data through the context:
@@ -42,9 +42,9 @@ export default class Title extends React.Component {
   }
 }
 Title.contextTypes = {
-  data: React.PropTypes.object,
-  get: React.PropTypes.func,
-  register: React.PropTypes.func
+  data: PropTypes.object,
+  get: PropTypes.func,
+  register: PropTypes.func
 };
 ```
 Ideally we don't want to specify the contextTypes every time when we need an access to the context.
@@ -84,9 +84,9 @@ export default function wire(Component, dependencies, mapper) {
     }
   }
   Inject.contextTypes = {
-    data: React.PropTypes.object,
-    get: React.PropTypes.func,
-    register: React.PropTypes.func
+    data: PropTypes.object,
+    get: PropTypes.func,
+    register: PropTypes.func
   };
   return Inject;
 };

--- a/patterns/33.format-text-via-component.md
+++ b/patterns/33.format-text-via-component.md
@@ -23,10 +23,10 @@ const Price = (props) => {
 };
 
 Price.propTypes = {
-  className: React.PropTypes.string,
-  children: React.PropTypes.number,
-  showDecimals: React.PropTypes.bool,
-  showSymbol: React.PropTypes.bool
+  className: PropTypes.string,
+  children: PropTypes.number,
+  showDecimals: PropTypes.bool,
+  showSymbol: PropTypes.bool
 };
 
 Price.defaultProps = {

--- a/ux-variations/01.composing-variations.md
+++ b/ux-variations/01.composing-variations.md
@@ -26,7 +26,8 @@ UX variations toggle features + add in additional links/markup.
 If the UX variations are involved toggling features within a component + adding minor markup around it
 
 ```javascript
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types';
 import SignIn from "./sign-in";
 
 class MemberSignIn extends Component {


### PR DESCRIPTION
Hello,

I think you're doing fantastic work in this repo, thanks for that! Just a small problem I noticed as I was reading the new release notes: As of React v15.5.0, PropTypes now exist in a different package,
`prop-types`. `React.PropTypes` is deprecated. 

Since using `React.PropTypes` gives a deprecation warning I think we should encourage using the new way.

Let me know what you think.

-- fvj