### PR TITLE
Fix page title and block of code

### DIFF
--- a/patterns/09.children-pass-through.md
+++ b/patterns/09.children-pass-through.md
@@ -1,4 +1,4 @@
-# Children types
+# Children Pass Through
 
 You might create a component designed to apply context and render its children:
 
@@ -26,7 +26,7 @@ return <div>{children}</div>;
 **Option 2: Unhelpful errors**
 ```javascript
 return children;
-```javascript
+```
 
 It’s best to treat children as an opaque data type. React provides React.Children for dealing with children appropriately.
 ```javascript


### PR DESCRIPTION
The page title was `Children Types` instead of `Children Pass Through` and the first block of code was bad closed, making MD considering some normal texts as part of the block.