### PR TITLE
Update 17.controlled-uncontrolled-input.md

### DIFF
--- a/patterns/17.controlled-uncontrolled-input.md
+++ b/patterns/17.controlled-uncontrolled-input.md
@@ -28,7 +28,7 @@ class UncontrolledNameInput extends React.Component {
   }
 
   render() {
-    return <input type="text" value={this.state.name} />
+    return <input type="text" />
   }
 };
 ```


### PR DESCRIPTION
Sorry for my blunt and upfront language. — I’m on an airport wifi and I just wanted to give feedback before I catch the plane, or lose connectivity (whichever comes first :) )

The example is misleading.

Whenever the input has a `value` prop, it will be controlled and you still would not be able to change its value.

Just forked this <https://jsfiddle.net/8nu2e8ut/> as a simple example to test.