### PR TITLE
[FIX] typo in SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -26,7 +26,7 @@
   - [Mixins](./anti-patterns/03.mixins.md)
   - [setState() in componentWillMount()](./anti-patterns/04.setState-in-componentWillMount.md)
   - [Mutating State](./anti-patterns/05.mutating-state.md)
-  - [Using Indexs as Key](./anti-patterns/06.using-indexes-as-key.md)
+  - [Using Indexes as Key](./anti-patterns/06.using-indexes-as-key.md)
   - [Spreading Props on DOM elements](./anti-patterns/07.spreading-props-dom.md)
 - Handling UX Variations
   - [Introduction](./ux-variations/README.md)


### PR DESCRIPTION
Hi! Thank you for this book, I am finding it very useful.  This PR fixes a small typo in `SUMMARY.md` where the word "Indexs" should be spelled "Indexes".  :)