### PR TITLE
Add `...rest` solution to spreading-props-dom anti-pattern

### DIFF
--- a/anti-patterns/07.spreading-props-dom.md
+++ b/anti-patterns/07.spreading-props-dom.md
@@ -14,6 +14,12 @@ const Sample = () => (<Spread flag={true} domProps={{className: "content"}}/>);
 const Spread = (props) => (<div {...props.domProps}>Test</div>);
 ```
 
+Or alternatively we can use prop destructuring with `...rest`:
+```javascript
+const Sample = () => (<Spread flag={true} className="content"/>);
+const Spread = ({ flag, ...domProps }) => (<div {...props}>Test</div>);
+```
+
 *Note*
 
 In [scenarios](https://github.com/vasanthk/react-bits/issues/34) where you use a [PureComponent](../perf-tips/02.pure-component.md), when an update happens it re-renders the component even if `domProps` did not changed. This is because PureComponent only [shallowly compares](https://facebook.github.io/react/docs/react-api.html#react.purecomponent) the objects.


### PR DESCRIPTION
This is the approach mentioned in the official docs here: https://reactjs.org/warnings/unknown-prop.html. Which is not to say that it's better than what's currently in this repo, but it can't help to list a couple of ways to solve the problem :)