### PR TITLE
Update 05.mutating-state.md

### DIFF
--- a/anti-patterns/05.mutating-state.md
+++ b/anti-patterns/05.mutating-state.md
@@ -50,9 +50,9 @@ class SampleComponent extends Component {
 
   handleClick() {
     // We update using setState() - concat return new array after appending new item.
-    this.setState({
-      items: this.state.items.concat('lorem')
-    });
+    this.setState(prevState => ({
+      items: prevState.items.concat('lorem')
+    }));
   }
 
   render() {


### PR DESCRIPTION
Replaced reference of `this.state` inside setState with function that takes prevState as parameter because this pattern avoids some nasty issues like:

```
this.setState({
  items: this.state.items.concat('lorem')
});

// items will not have 'lorem' here, oops
this.setState({
  items: this.state.items.concat('ipsum')
});
```