### PR TITLE
Fix: Move renderSearchSuggestion outside component to prevent functio…

### DIFF
--- a/patterns/15.list-components.md
+++ b/patterns/15.list-components.md
@@ -3,13 +3,13 @@ Lists and other things that are almost components
 
 Instead of making a separate component for lists I can then generate the results like:
 ```javascript
-const SearchSuggestions = (props) => {
-  // renderSearchSuggestion() behaves as a pseudo SearchSuggestion component
-  // keep it self contained and it should be easy to extract later if needed
-  const renderSearchSuggestion = listItem => (
-    <li key={listItem.id}>{listItem.name} {listItem.id}</li>
-  );
+// renderSearchSuggestion() behaves as a pseudo SearchSuggestion component
+// keep it self contained and it should be easy to extract later if needed
+const renderSearchSuggestion = listItem => (
+  <li key={listItem.id}>{listItem.name} {listItem.id}</li>
+);
 
+const SearchSuggestions = (props) => {
   return (
     <ul>
       {props.listItems.map(renderSearchSuggestion)}


### PR DESCRIPTION
## Description
This PR fixes issue #89 by moving the `renderSearchSuggestion` function outside the `SearchSuggestions` component definition to prevent creating a new function on each render.

## Problem
Previously, `renderSearchSuggestion` was defined inside the `SearchSuggestions` component, which meant a new function was created every time the component re-rendered. This is inefficient and can cause unnecessary re-renders of child components.

## Solution
Moved `renderSearchSuggestion` outside the component definition so it's only created once and reused across renders.

## Changes
- Moved `renderSearchSuggestion` function definition above `SearchSuggestions` component
- Updated code example in `patterns/15.list-components.md`

## Beforeript
const SearchSuggestions = (props) => {
  const renderSearchSuggestion = listItem => (
    <li key={listItem.id}>{listItem.name} {listItem.id}</li>
  );
  // ...
};

## Afterscript
const renderSearchSuggestion = listItem => (
  <li key={listItem.id}>{listItem.name} {listItem.id}</li>
);

const SearchSuggestions = (props) => {
  // ...
};

Fixes #89
